### PR TITLE
Changed setting of originalmatrix to be compatible with PGraphics objects

### DIFF
--- a/src/peasy/PeasyCam.java
+++ b/src/peasy/PeasyCam.java
@@ -122,7 +122,9 @@ public class PeasyCam {
 		this.startCenter = this.center = new Vector3D(lookAtX, lookAtY, lookAtZ);
 		this.startDistance = this.distance = distance;
 		this.rotation = new Rotation();
-		this.originalMatrix = parent.getMatrix((PMatrix3D)null);
+		g.beginDraw(); //Make sure camera on the PGraphics is initialized.  We basically use beginDraw to call the protected setViewport method of PGraphicsOpenGL 
+		g.endDraw();
+		this.originalMatrix = g.getMatrix((PMatrix3D)null);
 
 		feed();
 


### PR DESCRIPTION
This fixes an issue where beginHUD wouldn't work properly on PGraphics objects sized differently than the PApplet.
