### PR TITLE
beginHUD/endHUD projection fix

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -2,6 +2,7 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="test"/>
+	<classpathentry kind="src" path="testHUD"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/processing-core"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="bin"/>

--- a/src/peasy/PeasyCam.java
+++ b/src/peasy/PeasyCam.java
@@ -596,7 +596,6 @@ public class PeasyCam {
 		
 	    g.pushStyle();
 	    g.pushMatrix();
-	    g.noLights();
 	    g.hint(PConstants.DISABLE_DEPTH_TEST);
 	    if(g.is3D() && g.isGL()){
 	      ((PGraphicsOpenGL) g).pushProjection();
@@ -604,6 +603,7 @@ public class PeasyCam {
 	    g.resetMatrix();
 	    if(g.is3D()){
 	      g.ortho(0, g.width, -g.height, 0, 0, 1);
+		    g.noLights();
 	    } 
 	}
 

--- a/src/peasy/PeasyCam.java
+++ b/src/peasy/PeasyCam.java
@@ -608,8 +608,6 @@ public class PeasyCam {
 		}
 		if(g.is3D()){
 			g.ortho(0, g.width, -g.height, 0, -Float.MAX_VALUE, +Float.MAX_VALUE);
-			PGraphicsOpenGL pgl = (PGraphicsOpenGL)g;
-			pgl.updateProjmodelview();
 		}
 	}
 

--- a/src/peasy/PeasyCam.java
+++ b/src/peasy/PeasyCam.java
@@ -28,6 +28,7 @@ import processing.core.PGraphics;
 import processing.core.PMatrix3D;
 import processing.event.KeyEvent;
 import processing.event.MouseEvent;
+import processing.opengl.PGraphicsOpenGL;
 
 /**
  * 
@@ -99,7 +100,7 @@ public class PeasyCam {
 	private final PeasyEventListener peasyEventListener = new PeasyEventListener();
 	private boolean isActive = false;
 
-	private final PMatrix3D originalMatrix; // for HUD restore
+//	private final PMatrix3D originalMatrix; // for HUD restore
 
 	public final String VERSION = "202";
 	
@@ -123,7 +124,7 @@ public class PeasyCam {
 		this.startCenter = this.center = new Vector3D(lookAtX, lookAtY, lookAtZ);
 		this.startDistance = this.distance = Math.max(distance, SMALLEST_MINIMUM_DISTANCE);
 		this.rotation = new Rotation();
-		this.originalMatrix = parent.getMatrix((PMatrix3D)null);
+//		this.originalMatrix = parent.getMatrix((PMatrix3D)null);
 
 		feed();
 
@@ -585,17 +586,37 @@ public class PeasyCam {
 	 * Thanks to A.W. Martin for the code to do HUD
 	 */
 	public void beginHUD() {
-		g.pushMatrix();
-		g.hint(PConstants.DISABLE_DEPTH_TEST);
-		// Load the identity matrix.
-		g.resetMatrix();
-		// Apply the original Processing transformation matrix.
-		g.applyMatrix(originalMatrix);
+//		g.pushMatrix();
+//		g.hint(PConstants.DISABLE_DEPTH_TEST);
+//		// Load the identity matrix.
+//		g.resetMatrix();
+//		// Apply the original Processing transformation matrix.
+//		g.applyMatrix(originalMatrix);
+		
+		
+	    g.pushStyle();
+	    g.pushMatrix();
+	    g.noLights();
+	    g.hint(PConstants.DISABLE_DEPTH_TEST);
+	    if(g.is3D() && g.isGL()){
+	      ((PGraphicsOpenGL) g).pushProjection();
+	    }
+	    g.resetMatrix();
+	    if(g.is3D()){
+	      g.ortho(0, g.width, -g.height, 0, 0, 1);
+	    } 
 	}
 
 	public void endHUD() {
-		g.hint(PConstants.ENABLE_DEPTH_TEST);
-		g.popMatrix();
+//		g.hint(PConstants.ENABLE_DEPTH_TEST);
+//		g.popMatrix();
+		
+	    if(g.is3D() && g.isGL()){
+	      ((PGraphicsOpenGL) g).popProjection();
+	    }
+	    g.hint(PConstants.ENABLE_DEPTH_TEST);
+	    g.popMatrix();
+	    g.popStyle();
 	}
 
 	abstract public class AbstractInterp {

--- a/src/peasy/PeasyCam.java
+++ b/src/peasy/PeasyCam.java
@@ -600,13 +600,12 @@ public class PeasyCam {
 		g.hint(PConstants.DISABLE_DEPTH_TEST);
 		g.pushMatrix();
 		g.resetMatrix();
-		if(g.isGL()){
+		// 3D is always GL (in processing 3), so this check is probably redundant.
+		if(g.isGL() && g.is3D()){
 			PGraphicsOpenGL pgl = (PGraphicsOpenGL)g;
-			pgl.pushProjection();
 			pushedLights = pgl.lights;
 			pgl.lights = false;
-		}
-		if(g.is3D()){
+			pgl.pushProjection();
 			g.ortho(0, g.width, -g.height, 0, -Float.MAX_VALUE, +Float.MAX_VALUE);
 		}
 	}
@@ -618,7 +617,7 @@ public class PeasyCam {
 	 * 
 	 */
 	public void endHUD() {
-		if(g.isGL()){
+		if(g.isGL() && g.is3D()){
 			PGraphicsOpenGL pgl = (PGraphicsOpenGL)g;
 			pgl.popProjection();
 			pgl.lights = pushedLights;

--- a/src/peasy/PeasyCam.java
+++ b/src/peasy/PeasyCam.java
@@ -582,7 +582,7 @@ public class PeasyCam {
 	
 	
 	
-	private boolean pushed_lights = false;
+	private boolean pushedLights = false;
 
 	/**
 	 * 
@@ -603,7 +603,7 @@ public class PeasyCam {
 		if(g.isGL()){
 			PGraphicsOpenGL pgl = (PGraphicsOpenGL)g;
 			pgl.pushProjection();
-			pushed_lights = pgl.lights;
+			pushedLights = pgl.lights;
 			pgl.lights = false;
 		}
 		if(g.is3D()){
@@ -621,8 +621,7 @@ public class PeasyCam {
 		if(g.isGL()){
 			PGraphicsOpenGL pgl = (PGraphicsOpenGL)g;
 			pgl.popProjection();
-			pgl.lights = pushed_lights;
-			pushed_lights = false;
+			pgl.lights = pushedLights;
 		}
 		g.popMatrix();
 		g.hint(PConstants.ENABLE_DEPTH_TEST);

--- a/src/peasy/PeasyCam.java
+++ b/src/peasy/PeasyCam.java
@@ -18,7 +18,6 @@
  */
 package peasy;
 
-import org.omg.CORBA.INTF_REPOS;
 
 import peasy.org.apache.commons.math.geometry.CardanEulerSingularityException;
 import peasy.org.apache.commons.math.geometry.Rotation;

--- a/src/peasy/PeasyCam.java
+++ b/src/peasy/PeasyCam.java
@@ -594,7 +594,7 @@ public class PeasyCam {
 //		g.applyMatrix(originalMatrix);
 		
 		
-	    g.pushStyle();
+	    // g.pushStyle();
 	    g.pushMatrix();
 	    g.hint(PConstants.DISABLE_DEPTH_TEST);
 	    if(g.is3D() && g.isGL()){
@@ -603,7 +603,7 @@ public class PeasyCam {
 	    g.resetMatrix();
 	    if(g.is3D()){
 	      g.ortho(0, g.width, -g.height, 0, 0, 1);
-		    g.noLights();
+	      g.noLights();
 	    } 
 	}
 
@@ -616,7 +616,7 @@ public class PeasyCam {
 	    }
 	    g.hint(PConstants.ENABLE_DEPTH_TEST);
 	    g.popMatrix();
-	    g.popStyle();
+	    // g.popStyle();
 	}
 
 	abstract public class AbstractInterp {

--- a/testHUD/test/Peasycam_testHUD.java
+++ b/testHUD/test/Peasycam_testHUD.java
@@ -65,6 +65,16 @@ public class Peasycam_testHUD extends PApplet {
     fill(0xFFFFFFFF); rect(       0,height-wh, wh, wh, 30);
     
     peasycam.endHUD();
+    
+    
+    // check if everything got restored
+    // Note: Depth testing was disabled during the HUD-drawing
+    translate(0,-80,0);
+    noStroke();
+    fill(128);
+    box(60);
+    
+    
   
   }
   

--- a/testHUD/test/Peasycam_testHUD.java
+++ b/testHUD/test/Peasycam_testHUD.java
@@ -1,0 +1,101 @@
+package test;
+
+import peasy.*;
+import processing.core.PApplet;
+import processing.core.PConstants;
+import processing.core.PGraphics;
+import processing.opengl.PGraphics2D;
+import processing.opengl.PGraphicsOpenGL;
+
+
+public class Peasycam_testHUD extends PApplet {
+  
+
+
+  // camera control
+  PeasyCam peasycam;
+  
+  PGraphics2D pg_screen;
+ 
+  public void settings() {
+    size(800, 600, P3D);
+    smooth(8);
+  }
+  
+  public void setup() {
+    // surface.setResizable(!true);
+    
+	// default FoV is 60
+    perspective(80 * DEG_TO_RAD, width/(float)height, 1, 5000);
+
+    // camera
+    peasycam = new PeasyCam(this, 300);
+    
+    
+    // just some mask for HUD display test
+    pg_screen = (PGraphics2D)createGraphics(width, height, P2D);
+    pg_screen.smooth(0);
+    pg_screen.beginDraw();
+    {
+    	pg_screen.clear();
+	    pg_screen.beginShape();
+	    pg_screen.fill(0xFF000000); pg_screen.vertex(0, 0);
+	    pg_screen.fill(0xFFFF0000); pg_screen.vertex(width, 0);
+	    pg_screen.fill(0xFFFFFFFF); pg_screen.vertex(width, height);
+	    pg_screen.fill(0xFF00FF00); pg_screen.vertex(0, height);
+	    pg_screen.endShape();
+	    pg_screen.blendMode(REPLACE);
+	    pg_screen.noStroke();
+	    pg_screen.fill(0,0);
+	    pg_screen.rect(20, 20, width-40, height-40);
+    }
+    pg_screen.endDraw();
+  }
+  
+  public void draw(){
+    
+	// surface.setResizable(!true);
+    // because of asynchronous surface resizing this has no effect in setup
+    // surface.setResizable(true);
+    // perspective(120 * DEG_TO_RAD, width/(float)height, 1, 5000);
+    // peasycam.feed();
+    
+	  
+	// 3D scene
+    pointLight(255, 128, 64, -200, -200, 10);
+    pointLight(64, 128, 255, +200, +200, 10);
+    
+    background(32);
+    
+    rectMode(CENTER);
+    strokeWeight(1);
+    stroke(0);
+    fill(128);
+    rect(0, 0, 400, 400);
+    
+    strokeWeight(2);
+    stroke(255, 64,  0); line(0,0,0,100,0,0);
+    stroke( 32,255, 32); line(0,0,0,0,100,0);
+    stroke(  0, 64,255); line(0,0,0,0,0,100);
+    
+    translate(80,80,80);
+    noStroke();
+    fill(128);
+    box(50);
+    
+
+    // screen-aligned 2D HUD
+    peasycam.beginHUD();
+    image(pg_screen, 0, 0);
+    peasycam.endHUD();
+  
+  }
+  
+
+  
+  public static void main(String args[]) {
+    PApplet.main(new String[] { Peasycam_testHUD.class.getName() });
+  }
+  
+}
+

--- a/testHUD/test/Peasycam_testHUD.java
+++ b/testHUD/test/Peasycam_testHUD.java
@@ -2,70 +2,43 @@ package test;
 
 import peasy.*;
 import processing.core.PApplet;
-import processing.opengl.PGraphics2D;
 
 
 public class Peasycam_testHUD extends PApplet {
   
 
-
-  // camera control
   PeasyCam peasycam;
   
-  PGraphics2D pg_screen;
- 
   public void settings() {
     size(800, 600, P3D);
     smooth(8);
   }
   
   public void setup() {
-//    surface.setResizable(true);
+    // surface.setResizable(true);
     
     // default FoV is 60
-    perspective(80 * DEG_TO_RAD, width/(float)height, 1, 5000);
+    perspective(90 * DEG_TO_RAD, width/(float)height, 1, 5000);
 
     // camera
     peasycam = new PeasyCam(this, 300);
-    
-    
-    // just some mask for HUD display test
-    pg_screen = (PGraphics2D)createGraphics(width, height, P2D);
-    pg_screen.smooth(0);
-    pg_screen.beginDraw();
-    {
-        pg_screen.clear();
-        pg_screen.beginShape();
-        pg_screen.fill(0xFF000000); pg_screen.vertex(0, 0);
-        pg_screen.fill(0xFFFF0000); pg_screen.vertex(width, 0);
-        pg_screen.fill(0xFFFFFFFF); pg_screen.vertex(width, height);
-        pg_screen.fill(0xFF00FF00); pg_screen.vertex(0, height);
-        pg_screen.endShape();
-        pg_screen.blendMode(REPLACE);
-        pg_screen.noStroke();
-        pg_screen.fill(0,0);
-        pg_screen.rect(20, 20, width-40, height-40);
-    }
-    pg_screen.endDraw();
   }
   
   public void draw(){
     
     // in case of surface resizing (happens asynchronous) this has no effect in setup
-    // perspective(120 * DEG_TO_RAD, width/(float)height, 1, 5000);
+	// perspective(90 * DEG_TO_RAD, width/(float)height, 1, 5000);
     // peasycam.feed();
-    
     
     // 3D scene
 	ambientLight(128, 128, 128);
     pointLight(255, 128, 64, -200, -200, 10);
     pointLight(64, 128, 255, +200, +200, 10);
     
-    background(16);
+    background(32);
     
     rectMode(CENTER);
-    strokeWeight(1);
-    stroke(0);
+    noStroke();
     fill(128);
     rect(0, 0, 400, 400);
     
@@ -82,21 +55,14 @@ public class Peasycam_testHUD extends PApplet {
     
     // screen-aligned 2D HUD
     peasycam.beginHUD();
-    image(pg_screen, 0, 0);
-    
 
-    translate(width/2, height/2);
-//    fill(255,0,0);
-//    rotateX(45*DEG_TO_RAD);
-//    lights();
-//    box(100);
-    
-    pushMatrix();
-    translate(0, 0, map(mouseX, 0, width, -100, 100));
-    fill(0,255,0);
-    rect(0, 0, 500, 200);
-    popMatrix();
-//    rect(10, 10, 200, 100);
+    int wh = 100;
+    rectMode(CORNER);
+    noStroke();
+    fill(0xFFFF0000); rect(       0,        0, wh, wh);
+    fill(0xFF00FF00); rect(width-wh,        0, wh, wh, 30);
+    fill(0xFF0000FF); rect(width-wh,height-wh, wh, wh);
+    fill(0xFFFFFFFF); rect(       0,height-wh, wh, wh, 30);
     
     peasycam.endHUD();
   

--- a/testHUD/test/Peasycam_testHUD.java
+++ b/testHUD/test/Peasycam_testHUD.java
@@ -83,6 +83,21 @@ public class Peasycam_testHUD extends PApplet {
     // screen-aligned 2D HUD
     peasycam.beginHUD();
     image(pg_screen, 0, 0);
+    
+
+    translate(width/2, height/2);
+//    fill(255,0,0);
+//    rotateX(45*DEG_TO_RAD);
+//    lights();
+//    box(100);
+    
+    pushMatrix();
+    translate(0, 0, map(mouseX, 0, width, -100, 100));
+    fill(0,255,0);
+    rect(0, 0, 500, 200);
+    popMatrix();
+//    rect(10, 10, 200, 100);
+    
     peasycam.endHUD();
   
   }

--- a/testHUD/test/Peasycam_testHUD.java
+++ b/testHUD/test/Peasycam_testHUD.java
@@ -2,10 +2,7 @@ package test;
 
 import peasy.*;
 import processing.core.PApplet;
-import processing.core.PConstants;
-import processing.core.PGraphics;
 import processing.opengl.PGraphics2D;
-import processing.opengl.PGraphicsOpenGL;
 
 
 public class Peasycam_testHUD extends PApplet {
@@ -23,9 +20,9 @@ public class Peasycam_testHUD extends PApplet {
   }
   
   public void setup() {
-    // surface.setResizable(!true);
+//    surface.setResizable(true);
     
-	// default FoV is 60
+    // default FoV is 60
     perspective(80 * DEG_TO_RAD, width/(float)height, 1, 5000);
 
     // camera
@@ -37,35 +34,34 @@ public class Peasycam_testHUD extends PApplet {
     pg_screen.smooth(0);
     pg_screen.beginDraw();
     {
-    	pg_screen.clear();
-	    pg_screen.beginShape();
-	    pg_screen.fill(0xFF000000); pg_screen.vertex(0, 0);
-	    pg_screen.fill(0xFFFF0000); pg_screen.vertex(width, 0);
-	    pg_screen.fill(0xFFFFFFFF); pg_screen.vertex(width, height);
-	    pg_screen.fill(0xFF00FF00); pg_screen.vertex(0, height);
-	    pg_screen.endShape();
-	    pg_screen.blendMode(REPLACE);
-	    pg_screen.noStroke();
-	    pg_screen.fill(0,0);
-	    pg_screen.rect(20, 20, width-40, height-40);
+        pg_screen.clear();
+        pg_screen.beginShape();
+        pg_screen.fill(0xFF000000); pg_screen.vertex(0, 0);
+        pg_screen.fill(0xFFFF0000); pg_screen.vertex(width, 0);
+        pg_screen.fill(0xFFFFFFFF); pg_screen.vertex(width, height);
+        pg_screen.fill(0xFF00FF00); pg_screen.vertex(0, height);
+        pg_screen.endShape();
+        pg_screen.blendMode(REPLACE);
+        pg_screen.noStroke();
+        pg_screen.fill(0,0);
+        pg_screen.rect(20, 20, width-40, height-40);
     }
     pg_screen.endDraw();
   }
   
   public void draw(){
     
-	// surface.setResizable(!true);
-    // because of asynchronous surface resizing this has no effect in setup
-    // surface.setResizable(true);
+    // in case of surface resizing (happens asynchronous) this has no effect in setup
     // perspective(120 * DEG_TO_RAD, width/(float)height, 1, 5000);
     // peasycam.feed();
     
-	  
-	// 3D scene
+    
+    // 3D scene
+	ambientLight(128, 128, 128);
     pointLight(255, 128, 64, -200, -200, 10);
     pointLight(64, 128, 255, +200, +200, 10);
     
-    background(32);
+    background(16);
     
     rectMode(CENTER);
     strokeWeight(1);
@@ -83,7 +79,7 @@ public class Peasycam_testHUD extends PApplet {
     fill(128);
     box(50);
     
-
+    
     // screen-aligned 2D HUD
     peasycam.beginHUD();
     image(pg_screen, 0, 0);


### PR DESCRIPTION
beginHUD/endHUD seems to fail for custom set camera projections, e.g. a FoV different than 60 degrees.
I just found this by accident and am a bit puzzled that I never encountered it before.

`
perspective(80 * DEG_TO_RAD, width/(float)height, 1, 5000);`


Before:
The rectangular border should align with the screen-border.
Note, lightning also effects the shading of the HUD-scope.
![bug_hud](https://user-images.githubusercontent.com/743399/31799544-ff6ffce2-b53a-11e7-822d-a08104c0dd63.jpg)

After:
![fixed_hud](https://user-images.githubusercontent.com/743399/31799546-00fec584-b53b-11e7-85a3-cf19d023397b.jpg)






Example (also in the PR):

```java

import peasy.*;

// camera control
PeasyCam peasycam;

PGraphics2D pg_screen;

public void settings() {
  size(800, 600, P3D);
  smooth(8);
}

public void setup() {
//    surface.setResizable(true);
  
  // default FoV is 60
  perspective(80 * DEG_TO_RAD, width/(float)height, 1, 5000);

  // camera
  peasycam = new PeasyCam(this, 300);
  
  
  // just some mask for HUD display test
  pg_screen = (PGraphics2D)createGraphics(width, height, P2D);
  pg_screen.smooth(0);
  pg_screen.beginDraw();
  {
      pg_screen.clear();
      pg_screen.beginShape();
      pg_screen.fill(0xFF000000); pg_screen.vertex(0, 0);
      pg_screen.fill(0xFFFF0000); pg_screen.vertex(width, 0);
      pg_screen.fill(0xFFFFFFFF); pg_screen.vertex(width, height);
      pg_screen.fill(0xFF00FF00); pg_screen.vertex(0, height);
      pg_screen.endShape();
      pg_screen.blendMode(REPLACE);
      pg_screen.noStroke();
      pg_screen.fill(0,0);
      pg_screen.rect(20, 20, width-40, height-40);
  }
  pg_screen.endDraw();
}

public void draw(){
  
  // in case of surface resizing (happens asynchronous) this has no effect in setup
  // perspective(120 * DEG_TO_RAD, width/(float)height, 1, 5000);
  // peasycam.feed();
  
  
  // 3D scene
  ambientLight(128, 128, 128);
  pointLight(255, 128, 64, -200, -200, 10);
  pointLight(64, 128, 255, +200, +200, 10);
  
  background(16);
  
  rectMode(CENTER);
  strokeWeight(1);
  stroke(0);
  fill(128);
  rect(0, 0, 400, 400);
  
  strokeWeight(2);
  stroke(255, 64,  0); line(0,0,0,100,0,0);
  stroke( 32,255, 32); line(0,0,0,0,100,0);
  stroke(  0, 64,255); line(0,0,0,0,0,100);
  
  translate(80,80,80);
  noStroke();
  fill(128);
  box(50);
  
  
  // screen-aligned 2D HUD
  peasycam.beginHUD();
  image(pg_screen, 0, 0);
  peasycam.endHUD();

}

```